### PR TITLE
Multiple runs and image support.

### DIFF
--- a/NetLogoBridge.java
+++ b/NetLogoBridge.java
@@ -1,5 +1,11 @@
 import py4j.GatewayServer;
+
+import java.awt.image.BufferedImage;
+import java.io.File;
 import java.io.IOException;
+
+import javax.imageio.ImageIO;
+
 import org.nlogo.api.CompilerException;
 import org.nlogo.api.LogoException;
 import org.nlogo.headless.HeadlessWorkspace;
@@ -11,12 +17,13 @@ public class NetLogoBridge {
 	public NetLogoBridge() {
 		ws = HeadlessWorkspace.newInstance();
 	}
-	
+
 	/**
 	 * Load a NetLogo model file into the headless workspace.
 	 * @param path: Path to the .nlogo file to load.
 	 */
 	public void openModel(String path) {
+		System.out.println("opening" + path);
 		try {
 			ws.open(path);
 		} catch (IOException e) {
@@ -26,6 +33,41 @@ public class NetLogoBridge {
 		} catch (LogoException e) {
 			e.printStackTrace();
 		}
+	}
+	
+	/**
+	 * Close the Netlogo file.
+	 * 
+	 */
+	public void closeModel(){
+		try {
+			ws.dispose();
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+		}
+	}
+	
+	/**
+	 * Create a new headless instance. 
+	 * Use this after closeModel() to instantiate a
+	 * new instance of Netlogo. Great for multiple runs!
+	 */
+	public void refresh(){
+		ws = HeadlessWorkspace.newInstance();
+	}
+	
+	/**
+	 * Export a view (the visualization area) to the Java file's working directory.
+	 * @param filename: Name used to save the file. Include .png (ex: file.png)
+	 */
+	public void exportView(String filename){
+		try {
+			BufferedImage img = ws.exportView();
+		    File outputfile = new File(filename);
+		    ImageIO.write(img, "png", outputfile);
+		} catch (IOException e) {
+		    e.printStackTrace();
+		}		
 	}
 	
 	/**


### PR DESCRIPTION
Adds support for multiple runs. User can closeModel(), which trashes the current workspace object. A new workspace instance can be instantiated with refresh(). This technique works for looping through a directory of files.

Also adds support for image export. exportView() will save a .png of what would be showing on the interface at that timestep.